### PR TITLE
Enable geometry shaders

### DIFF
--- a/examples/grid_positions.py
+++ b/examples/grid_positions.py
@@ -1,0 +1,23 @@
+import yt
+
+import yt_idv
+
+ds = yt.load_sample("IsolatedGalaxy")
+dd = ds.all_data()
+
+rc = yt_idv.render_context("egl", width=1024, height=1024)
+rc.add_scene(dd, "density", no_ghost=True)
+rc.scene.components[0].visible = False
+
+from yt_idv.scene_annotations.grid_outlines import GridOutlines  # NOQA
+from yt_idv.scene_data.grid_positions import GridPositions  # NOQA
+
+grids = ds.index.grids.tolist()
+
+gp = GridPositions(grid_list=grids)
+rc.scene.data_objects.append(gp)
+go = GridOutlines(data=gp)
+rc.scene.components.append(go)
+
+image = rc.run()
+yt.write_bitmap(image, "step1.png")

--- a/yt_idv/scene_annotations/box.py
+++ b/yt_idv/scene_annotations/box.py
@@ -10,6 +10,7 @@ class BoxAnnotation(SceneAnnotation):
     name = "box_outline"
     data = traitlets.Instance(BoxData)
     box_width = traitlets.CFloat(0.05)
+    box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
     box_alpha = traitlets.CFloat(1.0)
 
     def draw(self, scene, program):
@@ -38,3 +39,4 @@ class BoxAnnotation(SceneAnnotation):
         shader_program._set_uniform("camera_pos", cam.position)
         shader_program._set_uniform("box_width", self.box_width)
         shader_program._set_uniform("box_alpha", self.box_alpha)
+        shader_program._set_uniform("box_color", np.array(self.box_color))

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -13,9 +13,9 @@ class GridOutlines(SceneAnnotation):
 
     name = "grid_outline"
     data = traitlets.Instance(GridPositions)
-    box_width = traitlets.CFloat(0.001)
+    box_width = traitlets.CFloat(0.05)
     box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
-    box_alpha = traitlets.CFloat(0.1)
+    box_alpha = traitlets.CFloat(1.0)
 
     def draw(self, scene, program):
         GL.glDrawArrays(GL.GL_POINTS, 0, len(self.data.grid_list))

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -13,12 +13,12 @@ class GridOutlines(SceneAnnotation):
 
     name = "grid_outline"
     data = traitlets.Instance(GridPositions)
-    box_width = traitlets.CFloat(0.1)
+    box_width = traitlets.CFloat(0.001)
     box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
-    box_alpha = traitlets.CFloat(1.0)
+    box_alpha = traitlets.CFloat(0.1)
 
     def draw(self, scene, program):
-        GL.glDrawArrays(GL.GL_LINES, 0, len(self.data.grid_list))
+        GL.glDrawArrays(GL.GL_POINTS, 0, len(self.data.grid_list))
 
     def _set_uniforms(self, scene, shader_program):
         cam = scene.camera

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -13,7 +13,7 @@ class GridOutlines(SceneAnnotation):
 
     name = "grid_outline"
     data = traitlets.Instance(GridPositions)
-    box_width = traitlets.CFloat(0.05)
+    box_width = traitlets.CFloat(0.25)  # quarter of a dx
     box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
     box_alpha = traitlets.CFloat(1.0)
 

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -1,0 +1,33 @@
+import numpy as np
+import traitlets
+from OpenGL import GL
+
+from yt_idv.scene_annotations.base_annotation import SceneAnnotation
+from yt_idv.scene_data.grid_positions import GridPositions
+
+
+class GridOutlines(SceneAnnotation):
+    """
+    A class that renders outlines of grid positions.
+    """
+
+    name = "grid_outline"
+    data = traitlets.Instance(GridPositions)
+    box_width = traitlets.CFloat(0.1)
+    box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
+    box_alpha = traitlets.CFloat(1.0)
+
+    def draw(self, scene, program):
+        GL.glDrawArrays(GL.GL_LINES, 0, len(self.data.grid_list))
+
+    def _set_uniforms(self, scene, shader_program):
+        cam = scene.camera
+        shader_program._set_uniform("projection", cam.projection_matrix)
+        shader_program._set_uniform("modelview", cam.view_matrix)
+        shader_program._set_uniform(
+            "viewport", np.array(GL.glGetIntegerv(GL.GL_VIEWPORT), dtype="f4")
+        )
+        shader_program._set_uniform("camera_pos", cam.position)
+        shader_program._set_uniform("box_width", self.box_width)
+        shader_program._set_uniform("box_color", np.array(self.box_color))
+        shader_program._set_uniform("box_alpha", self.box_alpha)

--- a/yt_idv/scene_data/grid_positions.py
+++ b/yt_idv/scene_data/grid_positions.py
@@ -11,7 +11,7 @@ class GridPositions(SceneData):
 
     @traitlets.default("vertex_array")
     def _default_vertex_array(self):
-        va = VertexArray(name="grid_bounds", each=1)
+        va = VertexArray(name="grid_bounds")
         positions = []
         dx = []
         le = []
@@ -20,12 +20,13 @@ class GridPositions(SceneData):
             dx.append(g.dds.tolist())
             le.append(g.LeftEdge.tolist())
             re.append(g.RightEdge.tolist())
-        positions = np.ones(len(self.grid_list) * 3, dtype="f4")
+        positions = np.ones((len(self.grid_list), 4), dtype="f4")
         dx = np.array(dx).astype("f4")
         le = np.array(le).astype("f4")
         re = np.array(re).astype("f4")
+        dx = re - le
         va.attributes.append(VertexAttribute(name="model_vertex", data=positions))
-        va.attributes.append(VertexAttribute(name="in_dx", data=dx))
         va.attributes.append(VertexAttribute(name="in_left_edge", data=le))
+        va.attributes.append(VertexAttribute(name="in_dx", data=dx))
         va.attributes.append(VertexAttribute(name="in_right_edge", data=re))
         return va

--- a/yt_idv/scene_data/grid_positions.py
+++ b/yt_idv/scene_data/grid_positions.py
@@ -1,0 +1,21 @@
+import numpy as np
+import traitlets
+
+from yt_idv.opengl_support import VertexArray, VertexAttribute
+from yt_idv.scene_data.base_data import SceneData
+
+
+class GridPositions(SceneData):
+    name = "grid_positions"
+    grid_list = traitlets.List()
+
+    @traitlets.default("vertex_array")
+    def _default_vertex_array(self):
+        va = VertexArray(name="grid_bounds", each=2)
+        positions = []
+        for g in self.grid_list:
+            positions.append(g.LeftEdge.tolist() + [1.0])
+            positions.append(g.RightEdge.tolist() + [1.0])
+        positions = np.array(positions, dtype="f4")
+        va.attributes.append(VertexAttribute(name="model_vertex", data=positions))
+        return va

--- a/yt_idv/scene_data/grid_positions.py
+++ b/yt_idv/scene_data/grid_positions.py
@@ -11,11 +11,21 @@ class GridPositions(SceneData):
 
     @traitlets.default("vertex_array")
     def _default_vertex_array(self):
-        va = VertexArray(name="grid_bounds", each=2)
+        va = VertexArray(name="grid_bounds", each=1)
         positions = []
+        dx = []
+        le = []
+        re = []
         for g in self.grid_list:
-            positions.append(g.LeftEdge.tolist() + [1.0])
-            positions.append(g.RightEdge.tolist() + [1.0])
-        positions = np.array(positions, dtype="f4")
+            dx.append(g.dds.tolist())
+            le.append(g.LeftEdge.tolist())
+            re.append(g.RightEdge.tolist())
+        positions = np.ones(len(self.grid_list) * 3, dtype="f4")
+        dx = np.array(dx).astype("f4")
+        le = np.array(le).astype("f4")
+        re = np.array(re).astype("f4")
         va.attributes.append(VertexAttribute(name="model_vertex", data=positions))
+        va.attributes.append(VertexAttribute(name="in_dx", data=dx))
+        va.attributes.append(VertexAttribute(name="in_left_edge", data=le))
+        va.attributes.append(VertexAttribute(name="in_right_edge", data=re))
         return va

--- a/yt_idv/scene_data/grid_positions.py
+++ b/yt_idv/scene_data/grid_positions.py
@@ -24,7 +24,6 @@ class GridPositions(SceneData):
         dx = np.array(dx).astype("f4")
         le = np.array(le).astype("f4")
         re = np.array(re).astype("f4")
-        dx = re - le
         va.attributes.append(VertexAttribute(name="model_vertex", data=positions))
         va.attributes.append(VertexAttribute(name="in_left_edge", data=le))
         va.attributes.append(VertexAttribute(name="in_dx", data=dx))

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -37,35 +37,47 @@ class ShaderProgram:
     fragment_shader : string
         or :class:`yt.visualization.volume_rendering.shader_objects.FragmentShader`
         The fragment shader used in the Interactive Data Visualization pipeline.
+
+    geometry_shader : string
+        or :class:`yt_idv.shader_objects.GeometryShader`
+        The geometry shader used in the pipeline; optional.
     """
 
-    def __init__(self, vertex_shader=None, fragment_shader=None):
+    def __init__(self, vertex_shader=None, fragment_shader=None, geometry_shader=None):
         # Don't allow just one.  Either neither or both.
         if vertex_shader is None and fragment_shader is None:
             pass
         elif None not in (vertex_shader, fragment_shader):
-            self.link(vertex_shader, fragment_shader)
+            # Geometry is optional
+            self.link(vertex_shader, fragment_shader, geometry_shader)
         else:
             raise RuntimeError
         self._uniform_funcs = OrderedDict()
 
-    def link(self, vertex_shader, fragment_shader):
-        # There are more types of shaders, but for now we only allow v&f.
+    def link(self, vertex_shader, fragment_shader, geometry_shader=None):
+        # We allow an optional geometry shader, but not tesselation (yet?)
         self.program = GL.glCreateProgram()
         if not isinstance(vertex_shader, Shader):
             vertex_shader = Shader(source=vertex_shader)
         if not isinstance(fragment_shader, Shader):
             fragment_shader = Shader(source=fragment_shader)
+        if geometry_shader is not None and not isinstance(geometry_shader, Shader):
+            geometry_shader = Shader(source=geometry_shader)
         self.vertex_shader = vertex_shader
         self.fragment_shader = fragment_shader
+        self.geometry_shader = geometry_shader
         GL.glAttachShader(self.program, vertex_shader.shader)
         GL.glAttachShader(self.program, fragment_shader.shader)
+        if geometry_shader is not None:
+            GL.glAttachShader(self.program, geometry_shader.shader)
         GL.glLinkProgram(self.program)
         result = GL.glGetProgramiv(self.program, GL.GL_LINK_STATUS)
         if not result:
             raise RuntimeError(GL.glGetProgramInfoLog(self.program))
         vertex_shader.delete_shader()
         fragment_shader.delete_shader()
+        if geometry_shader is not None:
+            geometry_shader.delete_shader()
         self.introspect()
 
     def introspect(self):
@@ -185,7 +197,7 @@ class Shader(traitlets.HasTraits):
     source = traitlets.Any()
     shader_name = traitlets.CUnicode()
     info = traitlets.CUnicode()
-    shader_type = traitlets.CaselessStrEnum(("vertex", "fragment"))
+    shader_type = traitlets.CaselessStrEnum(("vertex", "fragment", "geometry"))
     blend_func = traitlets.Tuple(
         GLValue(), GLValue(), default_value=("src alpha", "dst alpha")
     )

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -287,7 +287,7 @@ class Shader(traitlets.HasTraits):
 
 class ShaderTrait(traitlets.TraitType):
     default_value = None
-    info_text = "A shader (vertex or fragment)"
+    info_text = "A shader (vertex, fragment or geometry)"
 
     def validate(self, obj, value):
         if isinstance(value, str):

--- a/yt_idv/shaders/block_outline.frag.glsl
+++ b/yt_idv/shaders/block_outline.frag.glsl
@@ -1,9 +1,7 @@
 #version 330
-in vec4 v_model;
-in vec3 v_camera_pos;
-in vec3 dx;
-in vec3 left_edge;
-in vec3 right_edge;
+flat in vec3 dx;
+flat in vec3 left_edge;
+flat in vec3 right_edge;
 flat in mat4 inverse_proj;
 flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
@@ -35,7 +33,7 @@ void main()
 
     vec3 dist = min(abs(ray_position - right_edge),
                     abs(ray_position - left_edge));
-    
+
     // We need to be close to more than one edge.
 
     int count = 0;

--- a/yt_idv/shaders/default.vert.glsl
+++ b/yt_idv/shaders/default.vert.glsl
@@ -8,9 +8,9 @@ out vec3 v_camera_pos;
 flat out mat4 inverse_proj;
 flat out mat4 inverse_mvm;
 flat out mat4 inverse_pmvm;
-out vec3 dx;
-out vec3 left_edge;
-out vec3 right_edge;
+flat out vec3 dx;
+flat out vec3 left_edge;
+flat out vec3 right_edge;
 
 //// Uniforms
 uniform vec3 camera_pos;

--- a/yt_idv/shaders/default.vert.glsl
+++ b/yt_idv/shaders/default.vert.glsl
@@ -3,8 +3,8 @@ in vec4 model_vertex; // The location of the vertex in model space
 in vec3 in_dx;
 in vec3 in_left_edge;
 in vec3 in_right_edge;
-out vec4 v_model;
-out vec3 v_camera_pos;
+flat out vec4 v_model;
+flat out vec3 v_camera_pos;
 flat out mat4 inverse_proj;
 flat out mat4 inverse_mvm;
 flat out mat4 inverse_pmvm;

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -1,54 +1,81 @@
 #version 330 core
 
-layout ( lines ) in;
+layout ( points ) in;
 layout ( triangle_strip, max_vertices = 36 ) out;
+
+uniform mat4 modelview;
+uniform mat4 projection;
+
+flat in vec3 vdx[];
+flat in vec3 vleft_edge[];
+flat in vec3 vright_edge[];
+
+flat out vec3 dx;
+flat out vec3 left_edge;
+flat out vec3 right_edge;
+
+flat in mat4 inverse_proj[];
+flat in mat4 inverse_mvm[];
+flat in mat4 inverse_pmvm[];
+
+uniform vec4 arrangement[36] = vec4[](
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 0.0, 1.0, 1.0),
+   vec4(0.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 1.0, 0.0, 1.0),
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 1.0, 0.0, 1.0),
+   vec4(1.0, 0.0, 1.0, 1.0),
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(1.0, 0.0, 0.0, 1.0),
+   vec4(1.0, 1.0, 0.0, 1.0),
+   vec4(1.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 1.0, 1.0, 1.0),
+   vec4(0.0, 1.0, 0.0, 1.0),
+   vec4(1.0, 0.0, 1.0, 1.0),
+   vec4(0.0, 0.0, 1.0, 1.0),
+   vec4(0.0, 0.0, 0.0, 1.0),
+   vec4(0.0, 1.0, 1.0, 1.0),
+   vec4(0.0, 0.0, 1.0, 1.0),
+   vec4(1.0, 0.0, 1.0, 1.0),
+   vec4(1.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 0.0, 0.0, 1.0),
+   vec4(1.0, 1.0, 0.0, 1.0),
+   vec4(1.0, 0.0, 0.0, 1.0),
+   vec4(1.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 0.0, 1.0, 1.0),
+   vec4(1.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 1.0, 0.0, 1.0),
+   vec4(0.0, 1.0, 0.0, 1.0),
+   vec4(1.0, 1.0, 1.0, 1.0),
+   vec4(0.0, 1.0, 0.0, 1.0),
+   vec4(0.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 1.0, 1.0, 1.0),
+   vec4(0.0, 1.0, 1.0, 1.0),
+   vec4(1.0, 0.0, 1.0, 1.0));
 
 void main() {
     // gl_PositionIn[0] is left edge
     // gl_PositionIn[1] is right edge
 
-    vec3 left_edge = gl_in[0].gl_Position.xyz;
-    vec3 right_edge = gl_in[1].gl_Position.xyz;
+    //left_edge = (inverse_pmvm[0] * gl_in[0].gl_Position).xyz;
+    //right_edge = (inverse_pmvm[1] * gl_in[1].gl_Position).xyz;
 
-    vec3 width = right_edge - left_edge;
+    vec3 width = vright_edge[0] - vleft_edge[0];
 
-    gl_Position = vec4(0,0,0,1.0);
+    vec4 newPos = vec4(0,0,0,1.0);
 
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
-    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+    for (int i = 0; i < 36; i++) {
+        newPos.xyz = vleft_edge[0] + 0.1 * width * arrangement[i].xyz;
+        newPos.w = 1.0;
+        gl_Position = projection * modelview * newPos;
+        left_edge = vleft_edge[0];
+        right_edge = vright_edge[0];
+        dx = vdx[0];
+        EmitVertex();
+    }
+    EndPrimitive();
 
 }

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -13,10 +13,14 @@ flat in vec3 vright_edge[];
 flat out vec3 dx;
 flat out vec3 left_edge;
 flat out vec3 right_edge;
+flat out mat4 inverse_proj;
+flat out mat4 inverse_mvm;
+flat out mat4 inverse_pmvm;
 
-flat in mat4 inverse_proj[];
-flat in mat4 inverse_mvm[];
-flat in mat4 inverse_pmvm[];
+
+flat in mat4 vinverse_proj[];
+flat in mat4 vinverse_mvm[];
+flat in mat4 vinverse_pmvm[];
 
 uniform vec4 arrangement[36] = vec4[](
    vec4(0.0, 0.0, 0.0, 1.0),
@@ -67,15 +71,19 @@ void main() {
 
     vec4 newPos = vec4(0,0,0,1.0);
 
-    for (int i = 0; i < 36; i++) {
-        newPos.xyz = vleft_edge[0] + 0.1 * width * arrangement[i].xyz;
-        newPos.w = 1.0;
-        gl_Position = projection * modelview * newPos;
-        left_edge = vleft_edge[0];
-        right_edge = vright_edge[0];
-        dx = vdx[0];
-        EmitVertex();
+    for (int i = 0; i < 12; i++) {
+        for (int j = 0; j < 3; j++) {
+            newPos = vec4(vleft_edge[0] + width * arrangement[i*3+j].xyz, 1.0);
+            gl_Position = projection * modelview * newPos;
+            left_edge = vleft_edge[0];
+            right_edge = vright_edge[0];
+            inverse_pmvm = vinverse_pmvm[0];
+            inverse_proj = vinverse_proj[0];
+            inverse_mvm = vinverse_mvm[0];
+            dx = vdx[0];
+            EmitVertex();
+        }
+        EndPrimitive();
     }
-    EndPrimitive();
 
 }

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -1,0 +1,54 @@
+#version 330 core
+
+layout ( lines ) in;
+layout ( triangle_strip, max_vertices = 36 ) out;
+
+void main() {
+    // gl_PositionIn[0] is left edge
+    // gl_PositionIn[1] is right edge
+
+    vec3 left_edge = gl_in[0].gl_Position.xyz;
+    vec3 right_edge = gl_in[1].gl_Position.xyz;
+
+    vec3 width = right_edge - left_edge;
+
+    gl_Position = vec4(0,0,0,1.0);
+
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 0.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(0.0, 1.0, 1.0); EmitVertex();
+    gl_Position.xyz = left_edge + width * vec3(1.0, 0.0, 1.0); EmitVertex();
+
+}

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -1,7 +1,7 @@
 #version 330 core
 
 layout ( points ) in;
-layout ( triangle_strip, max_vertices = 36 ) out;
+layout ( triangle_strip, max_vertices = 14 ) out;
 
 uniform mat4 modelview;
 uniform mat4 projection;
@@ -22,68 +22,40 @@ flat in mat4 vinverse_proj[];
 flat in mat4 vinverse_mvm[];
 flat in mat4 vinverse_pmvm[];
 
-uniform vec4 arrangement[36] = vec4[](
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 0.0, 1.0, 1.0),
-   vec4(0.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 1.0, 0.0, 1.0),
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 1.0, 0.0, 1.0),
-   vec4(1.0, 0.0, 1.0, 1.0),
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(1.0, 0.0, 0.0, 1.0),
-   vec4(1.0, 1.0, 0.0, 1.0),
-   vec4(1.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 1.0, 1.0, 1.0),
-   vec4(0.0, 1.0, 0.0, 1.0),
-   vec4(1.0, 0.0, 1.0, 1.0),
-   vec4(0.0, 0.0, 1.0, 1.0),
-   vec4(0.0, 0.0, 0.0, 1.0),
-   vec4(0.0, 1.0, 1.0, 1.0),
-   vec4(0.0, 0.0, 1.0, 1.0),
-   vec4(1.0, 0.0, 1.0, 1.0),
-   vec4(1.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 0.0, 0.0, 1.0),
-   vec4(1.0, 1.0, 0.0, 1.0),
-   vec4(1.0, 0.0, 0.0, 1.0),
-   vec4(1.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 0.0, 1.0, 1.0),
-   vec4(1.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 1.0, 0.0, 1.0),
-   vec4(0.0, 1.0, 0.0, 1.0),
-   vec4(1.0, 1.0, 1.0, 1.0),
-   vec4(0.0, 1.0, 0.0, 1.0),
-   vec4(0.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 1.0, 1.0, 1.0),
-   vec4(0.0, 1.0, 1.0, 1.0),
-   vec4(1.0, 0.0, 1.0, 1.0));
+// https://stackoverflow.com/questions/28375338/cube-using-single-gl-triangle-strip
+// suggests that the triangle strip we want for the cube is
+
+uniform vec3 arrangement[8] = vec3[](
+    vec3(0, 0, 0),
+    vec3(1, 0, 0),
+    vec3(0, 1, 0),
+    vec3(1, 1, 0),
+    vec3(0, 0, 1),
+    vec3(1, 0, 1),
+    vec3(0, 1, 1),
+    vec3(1, 1, 1)
+);
+
+uniform int aindex[14] = int[](6, 7, 4, 5, 1, 7, 3, 6, 2, 4, 0, 1, 2, 3);
 
 void main() {
-    // gl_PositionIn[0] is left edge
-    // gl_PositionIn[1] is right edge
 
-    //left_edge = (inverse_pmvm[0] * gl_in[0].gl_Position).xyz;
-    //right_edge = (inverse_pmvm[1] * gl_in[1].gl_Position).xyz;
+    vec4 center = gl_in[0].gl_Position;
 
     vec3 width = vright_edge[0] - vleft_edge[0];
 
-    vec4 newPos = vec4(0,0,0,1.0);
+    vec4 newPos;
 
-    for (int i = 0; i < 12; i++) {
-        for (int j = 0; j < 3; j++) {
-            newPos = vec4(vleft_edge[0] + width * arrangement[i*3+j].xyz, 1.0);
-            gl_Position = projection * modelview * newPos;
-            left_edge = vleft_edge[0];
-            right_edge = vright_edge[0];
-            inverse_pmvm = vinverse_pmvm[0];
-            inverse_proj = vinverse_proj[0];
-            inverse_mvm = vinverse_mvm[0];
-            dx = vdx[0];
-            EmitVertex();
-        }
-        EndPrimitive();
+    for (int i = 0; i < 14; i++) {
+        newPos = vec4(vleft_edge[0] + width * arrangement[aindex[i]], 1.0);
+        gl_Position = projection * modelview * newPos;
+        left_edge = vleft_edge[0];
+        right_edge = vright_edge[0];
+        inverse_pmvm = vinverse_pmvm[0];
+        inverse_proj = vinverse_proj[0];
+        inverse_mvm = vinverse_mvm[0];
+        dx = vdx[0];
+        EmitVertex();
     }
 
 }

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -1,0 +1,27 @@
+#version 330
+in vec4 model_vertex; // The location of the vertex in model space
+out vec4 v_model;
+out vec3 v_camera_pos;
+flat out mat4 inverse_proj;
+flat out mat4 inverse_mvm;
+flat out mat4 inverse_pmvm;
+
+//// Uniforms
+uniform vec3 camera_pos;
+uniform mat4 modelview;
+uniform mat4 projection;
+
+uniform float near_plane;
+uniform float far_plane;
+
+void main()
+{
+    v_model = model_vertex;
+    v_camera_pos = camera_pos;
+    inverse_proj = inverse(projection);
+    // inverse model-view-matrix
+    inverse_mvm = inverse(modelview);
+    inverse_pmvm = inverse(projection * modelview);
+    gl_Position = projection * modelview * model_vertex;
+
+}

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -1,10 +1,16 @@
 #version 330
 in vec4 model_vertex; // The location of the vertex in model space
+in vec3 in_dx;
+in vec3 in_left_edge;
+in vec3 in_right_edge;
 out vec4 v_model;
 out vec3 v_camera_pos;
 flat out mat4 inverse_proj;
 flat out mat4 inverse_mvm;
 flat out mat4 inverse_pmvm;
+flat out vec3 vdx;
+flat out vec3 vleft_edge;
+flat out vec3 vright_edge;
 
 //// Uniforms
 uniform vec3 camera_pos;
@@ -23,5 +29,8 @@ void main()
     inverse_mvm = inverse(modelview);
     inverse_pmvm = inverse(projection * modelview);
     gl_Position = projection * modelview * model_vertex;
+    vdx = vec3(in_dx);
+    vleft_edge = vec3(in_left_edge);
+    vright_edge = vec3(in_right_edge);
 
 }

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -5,9 +5,9 @@ in vec3 in_left_edge;
 in vec3 in_right_edge;
 out vec4 v_model;
 out vec3 v_camera_pos;
-flat out mat4 inverse_proj;
-flat out mat4 inverse_mvm;
-flat out mat4 inverse_pmvm;
+flat out mat4 vinverse_proj;
+flat out mat4 vinverse_mvm;
+flat out mat4 vinverse_pmvm;
 flat out vec3 vdx;
 flat out vec3 vleft_edge;
 flat out vec3 vright_edge;
@@ -24,10 +24,10 @@ void main()
 {
     v_model = model_vertex;
     v_camera_pos = camera_pos;
-    inverse_proj = inverse(projection);
+    vinverse_proj = inverse(projection);
     // inverse model-view-matrix
-    inverse_mvm = inverse(modelview);
-    inverse_pmvm = inverse(projection * modelview);
+    vinverse_mvm = inverse(modelview);
+    vinverse_pmvm = inverse(projection * modelview);
     gl_Position = projection * modelview * model_vertex;
     vdx = vec3(in_dx);
     vleft_edge = vec3(in_left_edge);

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -1,9 +1,9 @@
 #version 330
-in vec4 v_model;
-in vec3 v_camera_pos;
-in vec3 dx;
-in vec3 left_edge;
-in vec3 right_edge;
+flat in vec4 v_model;
+flat in vec3 v_camera_pos;
+flat in vec3 dx;
+flat in vec3 left_edge;
+flat in vec3 right_edge;
 flat in mat4 inverse_proj;
 flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
@@ -65,7 +65,7 @@ void main()
     vec3 tr = (right_edge - ray_position)*idir;
 
     vec3 tmin = min(tl, tr);
-    vec3 tmax = max(tl, tr); 
+    vec3 tmax = max(tl, tr);
 
     vec2 temp_t;
 

--- a/yt_idv/shaders/shaderlist.yaml
+++ b/yt_idv/shaders/shaderlist.yaml
@@ -103,12 +103,19 @@ shader_definitions:
     passthrough:
       info: A second pass vertex shader that performs no operations on vertices
       source: passthrough.vert.glsl
+    grid_position:
+      info: Pass some grid positions on through
+      source: grid_position.vert.glsl
     draw_lines:
       info: A line drawing vertex shader
       source: draw_lines.vert.glsl
     text_overlay:
       info: A simple text overlay shader
       source: textoverlay.vert.glsl
+  geometry:
+    grid_expand:
+      info: Expand grid left and right edges into a set of triangles
+      source: grid_expand.geom.glsl
 component_shaders:
   block_rendering:
     default_value: max_intensity
@@ -135,6 +142,15 @@ component_shaders:
     default:
       description: Default
       first_vertex: default
+      first_fragment: draw_blocks
+      second_vertex: passthrough
+      second_fragment: passthrough
+  grid_outline:
+    default_value: default
+    default:
+      description: Default
+      first_vertex: grid_position
+      first_geometry: grid_expand
       first_fragment: draw_blocks
       second_vertex: passthrough
       second_fragment: passthrough


### PR DESCRIPTION
This adds the ability to use geometry shaders.  First implemented was a "grid outline" shader, which displays (similar to blocks and boxes) the grid positions.  This will reduce the amount of data we need to push to the GPU and store there (but not by an enormous amount) for grids.  The real improvement will be when using particles, as we'll be able to emit vertices for particles based on calculations done on the GPU, rather than needing to push them in initially.
