### PR TITLE
Switch to using GL_POINTS with a geom shader for blocks

### DIFF
--- a/yt_idv/scene_components/blocks.py
+++ b/yt_idv/scene_components/blocks.py
@@ -100,11 +100,13 @@ class BlockRendering(SceneComponent):
 
     def draw(self, scene, program):
         each = self.data.vertex_array.each
+        GL.glEnable(GL.GL_CULL_FACE)
+        GL.glCullFace(GL.GL_BACK)
         with self.transfer_function.bind(target=2):
             for tex_ind, tex, bitmap_tex in self.data.viewpoint_iter(scene.camera):
                 with tex.bind(target=0):
                     with bitmap_tex.bind(target=1):
-                        GL.glDrawArrays(GL.GL_TRIANGLES, tex_ind * each, each)
+                        GL.glDrawArrays(GL.GL_POINTS, tex_ind * each, each)
 
     def _set_uniforms(self, scene, shader_program):
         cam = scene.camera

--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -4,12 +4,7 @@ import numpy as np
 import traitlets
 from yt.data_objects.data_containers import YTDataContainer
 
-from yt_idv.opengl_support import (
-    Texture3D,
-    VertexArray,
-    VertexAttribute,
-    compute_box_geometry,
-)
+from yt_idv.opengl_support import Texture3D, VertexArray, VertexAttribute
 from yt_idv.scene_data.base_data import SceneData
 
 
@@ -25,7 +20,7 @@ class BlockCollection(SceneData):
 
     @traitlets.default("vertex_array")
     def _default_vertex_array(self):
-        return VertexArray(name="block_info", each=36)
+        return VertexArray(name="block_info", each=1)
 
     def add_data(self, field, no_ghost=False):
         r"""Adds a source of data for the block collection.
@@ -64,12 +59,11 @@ class BlockCollection(SceneData):
             self.min_val = min(self.min_val, np.nanmin(np.abs(block.my_data[0]).min()))
             self.max_val = max(self.max_val, np.nanmax(np.abs(block.my_data[0]).max()))
             self.blocks[id(block)] = (i, block)
-            vert.append(compute_box_geometry(block.LeftEdge, block.RightEdge))
-            dds = (block.RightEdge - block.LeftEdge) / block.my_data[0].shape
-            n = int(vert[-1].size) // 4
-            dx.append([dds.astype("f4") for _ in range(n)])
-            le.append([block.LeftEdge.astype("f4") for _ in range(n)])
-            re.append([block.RightEdge.astype("f4") for _ in range(n)])
+            vert.append([1.0, 1.0, 1.0, 1.0])
+            dds = (block.RightEdge - block.LeftEdge) / block.source_mask.shape
+            dx.append(dds.tolist())
+            le.append(block.LeftEdge.tolist())
+            re.append(block.RightEdge.tolist())
         for (g, node, (sl, _dims, _gi)) in self.data_source.tiles.slice_traverse():
             block = node.data
             self.blocks_by_grid[g.id - g._id_offset].append((id(block), i))
@@ -84,10 +78,10 @@ class BlockCollection(SceneData):
         RE = np.array([b.RightEdge for i, b in self.blocks.values()]).max(axis=0)
         self.diagonal = np.sqrt(((RE - LE) ** 2).sum())
         # Now we set up our buffer
-        vert = np.concatenate(vert)
-        dx = np.concatenate(dx)
-        le = np.concatenate(le)
-        re = np.concatenate(re)
+        vert = np.array(vert, dtype="f4")
+        dx = np.array(dx, dtype="f4")
+        le = np.array(le, dtype="f4")
+        re = np.array(re, dtype="f4")
 
         self.vertex_array.attributes.append(
             VertexAttribute(name="model_vertex", data=vert)

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -16,11 +16,14 @@ flat out vec3 right_edge;
 flat out mat4 inverse_proj;
 flat out mat4 inverse_mvm;
 flat out mat4 inverse_pmvm;
-
+flat out vec4 v_model;
+flat out vec3 v_camera_pos;
 
 flat in mat4 vinverse_proj[];
 flat in mat4 vinverse_mvm[];
 flat in mat4 vinverse_pmvm[];
+flat in vec4 vv_model[];
+flat in vec3 vv_camera_pos[];
 
 // https://stackoverflow.com/questions/28375338/cube-using-single-gl-triangle-strip
 // suggests that the triangle strip we want for the cube is
@@ -55,6 +58,8 @@ void main() {
         inverse_proj = vinverse_proj[0];
         inverse_mvm = vinverse_mvm[0];
         dx = vdx[0];
+        v_model = vv_model[0];
+        v_camera_pos = vv_camera_pos[0];
         EmitVertex();
     }
 

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -3,8 +3,8 @@ in vec4 model_vertex; // The location of the vertex in model space
 in vec3 in_dx;
 in vec3 in_left_edge;
 in vec3 in_right_edge;
-out vec4 v_model;
-out vec3 v_camera_pos;
+flat out vec4 vv_model;
+flat out vec3 vv_camera_pos;
 flat out mat4 vinverse_proj;
 flat out mat4 vinverse_mvm;
 flat out mat4 vinverse_pmvm;
@@ -22,8 +22,8 @@ uniform float far_plane;
 
 void main()
 {
-    v_model = model_vertex;
-    v_camera_pos = camera_pos;
+    vv_model = model_vertex;
+    vv_camera_pos = camera_pos;
     vinverse_proj = inverse(projection);
     // inverse model-view-matrix
     vinverse_mvm = inverse(modelview);

--- a/yt_idv/shaders/shaderlist.yaml
+++ b/yt_idv/shaders/shaderlist.yaml
@@ -121,19 +121,22 @@ component_shaders:
     default_value: max_intensity
     max_intensity:
       description: Maximum Intensity
-      first_vertex: default
+      first_vertex: grid_position
+      first_geometry: grid_expand
       first_fragment: max_intensity
       second_vertex: passthrough
       second_fragment: apply_colormap
     projection:
       description: Projective integration
-      first_vertex: default
+      first_vertex: grid_position
+      first_geometry: grid_expand
       first_fragment: projection
       second_vertex: passthrough
       second_fragment: apply_colormap
     transfer_function:
       description: Color transfer function
-      first_vertex: default
+      first_vertex: grid_position
+      first_geometry: grid_expand
       first_fragment: transfer_function
       second_vertex: passthrough
       second_fragment: passthrough
@@ -141,7 +144,8 @@ component_shaders:
     default_value: default
     default:
       description: Default
-      first_vertex: default
+      first_vertex: grid_position
+      first_geometry: grid_expand
       first_fragment: draw_blocks
       second_vertex: passthrough
       second_fragment: passthrough


### PR DESCRIPTION
This builds on the previous work and switches to using a geometry shader for block rendering.  This saves us a factor of 36 in the amount of *index* data we pass to the GPU, which is not that *much* (since it's just index data) but which is definitely annoying to do and manage.
