### PR TITLE
Fix mesh rendering and uniformize shader variables

### DIFF
--- a/examples/mesh_render.py
+++ b/examples/mesh_render.py
@@ -1,0 +1,24 @@
+import yt
+
+import yt_idv
+
+ds = yt.load_sample("MOOSE_Sample_data", "out.e-s010")
+
+rc = yt_idv.render_context(height=800, width=800, gui=True)
+
+from yt_idv.cameras.trackball_camera import TrackballCamera  # NOQA
+from yt_idv.scene_components.mesh import MeshRendering  # NOQA
+from yt_idv.scene_data.mesh import MeshData  # NOQA
+from yt_idv.scene_graph import SceneGraph  # NOQA
+
+c = TrackballCamera(position=[3.5, 3.5, 3.5], focus=[0.0, 0.0, 0.0])
+rc.scene = SceneGraph(camera=c)
+
+dd = ds.all_data()
+md = MeshData(data_source=dd)
+md.add_data(("connect1", "diffused"))
+mr = MeshRendering(data=md, cmap_log=False)
+
+rc.scene.data_objects.append(md)
+rc.scene.components.append(mr)
+rc.run()

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -197,8 +197,8 @@ class SceneComponent(traitlets.HasTraits):
                 with self.program2.enable() as p2:
                     with scene.bind_buffer():
                         p2._set_uniform("cmap", 0)
-                        p2._set_uniform("fb_texture", 1)
-                        p2._set_uniform("db_texture", 2)
+                        p2._set_uniform("fb_tex", 1)
+                        p2._set_uniform("db_tex", 2)
                         # Note that we use cmap_min/cmap_max, not
                         # self.cmap_min/self.cmap_max.
                         p2._set_uniform("cmap_min", cmap_min)

--- a/yt_idv/scene_components/mesh.py
+++ b/yt_idv/scene_components/mesh.py
@@ -1,4 +1,3 @@
-import numpy as np
 import traitlets
 from OpenGL import GL
 
@@ -14,7 +13,6 @@ class MeshRendering(SceneComponent):
         GL.glDrawElements(GL.GL_TRIANGLES, self.data.size, GL.GL_UNSIGNED_INT, None)
 
     def _set_uniforms(self, scene, shader_program):
-        projection_matrix = scene.camera.projection_matrix
-        view_matrix = scene.camera.view_matrix
-        model_to_clip = np.dot(projection_matrix, view_matrix)
-        shader_program._set_uniform("model_to_clip", model_to_clip)
+        cam = scene.camera
+        shader_program._set_uniform("projection", cam.projection_matrix)
+        shader_program._set_uniform("modelview", cam.view_matrix)

--- a/yt_idv/scene_components/rgba.py
+++ b/yt_idv/scene_components/rgba.py
@@ -13,7 +13,7 @@ class RGBADisplay(SceneComponent):
     priority = 20
 
     def _set_uniforms(self, scene, shader_program):
-        shader_program._set_uniform("cm_texture", 0)
+        shader_program._set_uniform("cm_tex", 0)
 
     def draw(self, scene, program):
         with self.data.colormap_texture.bind(0):

--- a/yt_idv/scene_data/mesh.py
+++ b/yt_idv/scene_data/mesh.py
@@ -1,3 +1,4 @@
+import numpy as np
 import traitlets
 from yt.data_objects.data_containers import YTDataContainer
 from yt.utilities.lib.mesh_triangulation import triangulate_mesh
@@ -41,13 +42,14 @@ class MeshData(SceneData):
     def add_data(self, field):
         v, d, i = self.get_mesh_data(self.data_source, field)
         v.shape = (v.size // 3, 3)
+        v = np.concatenate([v, np.ones((v.shape[0], 1))], axis=-1)
         d.shape = (d.size, 1)
         i.shape = (i.size, 1)
         i = i.astype("uint32")
         self.vertex_array.attributes.append(
-            VertexAttribute(name="vertexPosition_modelspace", data=v)
+            VertexAttribute(name="model_vertex", data=v)
         )
-        self.vertex_array.attributes.append(VertexAttribute(name="vertexData", data=d))
+        self.vertex_array.attributes.append(VertexAttribute(name="vertex_data", data=d))
         self.vertex_array.indices = i
         self.size = i.size
 

--- a/yt_idv/scene_data/mesh.py
+++ b/yt_idv/scene_data/mesh.py
@@ -42,14 +42,17 @@ class MeshData(SceneData):
     def add_data(self, field):
         v, d, i = self.get_mesh_data(self.data_source, field)
         v.shape = (v.size // 3, 3)
-        v = np.concatenate([v, np.ones((v.shape[0], 1))], axis=-1)
+        v = np.concatenate([v, np.ones((v.shape[0], 1))], axis=-1).astype("f4")
         d.shape = (d.size, 1)
         i.shape = (i.size, 1)
         i = i.astype("uint32")
+        # d[:] = np.mgrid[0.0:1.0:1j*d.size].astype("f4")[:,None]
         self.vertex_array.attributes.append(
             VertexAttribute(name="model_vertex", data=v)
         )
-        self.vertex_array.attributes.append(VertexAttribute(name="vertex_data", data=d))
+        self.vertex_array.attributes.append(
+            VertexAttribute(name="vertex_data", data=d.astype("f4"))
+        )
         self.vertex_array.indices = i
         self.size = i.size
 

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -227,6 +227,7 @@ class Shader(traitlets.HasTraits):
         # files.
         if not isinstance(source, (tuple, list)):
             source = (source,)
+        source = ("header.inc.glsl", "known_uniforms.inc.glsl",) + tuple(source)
         full_source = []
         for fn in source:
             if os.path.isfile(fn):

--- a/yt_idv/shaders/apply_colormap.frag.glsl
+++ b/yt_idv/shaders/apply_colormap.frag.glsl
@@ -4,16 +4,16 @@ in vec2 UV;
 
 out vec4 color;
 
-uniform sampler2D fb_texture;
-uniform sampler2D db_texture;
-uniform sampler1D cmap;
+uniform sampler2D fb_tex;
+uniform sampler2D db_tex;
+uniform sampler1D cm_tex;
 uniform float cmap_min;
 uniform float cmap_max;
 uniform float cmap_log;
 
 void main(){
-   float scaled = texture(fb_texture, UV).x;
-   float alpha = texture(fb_texture, UV).a;
+   float scaled = texture(fb_tex, UV).x;
+   float alpha = texture(fb_tex, UV).a;
    if (alpha == 0.0) discard;
    float cm = cmap_min;
    float cp = cmap_max;
@@ -23,6 +23,6 @@ void main(){
       cm = log(cm);
       cp = log(cp);
    }
-   color = texture(cmap, (scaled - cm) / (cp - cm));
-   gl_FragDepth = texture(db_texture, UV).r;
+   color = texture(cm_tex, (scaled - cm) / (cp - cm));
+   gl_FragDepth = texture(db_tex, UV).r;
 }

--- a/yt_idv/shaders/apply_colormap.frag.glsl
+++ b/yt_idv/shaders/apply_colormap.frag.glsl
@@ -1,15 +1,6 @@
-#version 330 core
-
 in vec2 UV;
 
 out vec4 color;
-
-uniform sampler2D fb_tex;
-uniform sampler2D db_tex;
-uniform sampler1D cm_tex;
-uniform float cmap_min;
-uniform float cmap_max;
-uniform float cmap_log;
 
 void main(){
    float scaled = texture(fb_tex, UV).x;

--- a/yt_idv/shaders/block_outline.frag.glsl
+++ b/yt_idv/shaders/block_outline.frag.glsl
@@ -1,4 +1,3 @@
-#version 330
 flat in vec3 dx;
 flat in vec3 left_edge;
 flat in vec3 right_edge;
@@ -6,15 +5,6 @@ flat in mat4 inverse_proj;
 flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
 out vec4 output_color;
-
-uniform vec4 viewport; // (offset_x, offset_y, 1 / screen_x, 1 / screen_y)
-uniform float box_width;
-uniform vec3 box_color;
-uniform float box_alpha;
-
-uniform vec3 camera_pos;
-uniform mat4 modelview;
-uniform mat4 projection;
 
 void main()
 {

--- a/yt_idv/shaders/box_outline.frag.glsl
+++ b/yt_idv/shaders/box_outline.frag.glsl
@@ -1,4 +1,3 @@
-#version 330
 in vec4 v_model;
 in vec3 v_camera_pos;
 in vec3 dx;
@@ -8,11 +7,6 @@ flat in mat4 inverse_proj;
 flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
 out vec4 output_color;
-
-uniform vec4 viewport; // (offset_x, offset_y, 1 / screen_x, 1 / screen_y)
-uniform float box_width;
-uniform vec3 box_color;
-uniform float box_alpha;
 
 //
 //  THIS IS CURRENTLY UNUSED
@@ -35,7 +29,7 @@ void main()
 
     vec3 dist = min(abs(ray_position - right_edge),
                       abs(ray_position - left_edge));
-    
+
     // We need to be close to more than one edge.
 
     int count = 0;

--- a/yt_idv/shaders/default.vert.glsl
+++ b/yt_idv/shaders/default.vert.glsl
@@ -1,4 +1,3 @@
-#version 330
 in vec4 model_vertex; // The location of the vertex in model space
 in vec3 in_dx;
 in vec3 in_left_edge;
@@ -11,14 +10,6 @@ flat out mat4 inverse_pmvm;
 flat out vec3 dx;
 flat out vec3 left_edge;
 flat out vec3 right_edge;
-
-//// Uniforms
-uniform vec3 camera_pos;
-uniform mat4 modelview;
-uniform mat4 projection;
-
-uniform float near_plane;
-uniform float far_plane;
 
 void main()
 {

--- a/yt_idv/shaders/draw_colormap.frag.glsl
+++ b/yt_idv/shaders/draw_colormap.frag.glsl
@@ -1,5 +1,3 @@
-#version 330 core
-
 in vec4 vColor;
 
 out vec4 color;

--- a/yt_idv/shaders/draw_lines.frag.glsl
+++ b/yt_idv/shaders/draw_lines.frag.glsl
@@ -1,6 +1,3 @@
-#version 330 core
-
-uniform int channel;
 out vec4 color;
 
 void main() {

--- a/yt_idv/shaders/draw_lines.vert.glsl
+++ b/yt_idv/shaders/draw_lines.vert.glsl
@@ -1,8 +1,5 @@
-#version 330 core
-
 in vec4 rgba_values;
 in float x_coord;
-uniform int channel;
 
 void main() {
     // our *actual* viewport goes from -1 to 1 in x and y, with 0 everywhere for z.

--- a/yt_idv/shaders/expand_1d.frag.glsl
+++ b/yt_idv/shaders/expand_1d.frag.glsl
@@ -1,9 +1,6 @@
-#version 330 core
-
 in vec2 UV;
 
 out vec4 color;
-uniform sampler1D cm_tex;
 
 void main(){
    color = texture(cm_tex, UV.x);

--- a/yt_idv/shaders/expand_1d.frag.glsl
+++ b/yt_idv/shaders/expand_1d.frag.glsl
@@ -3,9 +3,9 @@
 in vec2 UV;
 
 out vec4 color;
-uniform sampler1D cm_texture;
+uniform sampler1D cm_tex;
 
 void main(){
-   color = texture(cm_texture, UV.x);
+   color = texture(cm_tex, UV.x);
    color.a = 1.0;
 }

--- a/yt_idv/shaders/grid_expand.geom.glsl
+++ b/yt_idv/shaders/grid_expand.geom.glsl
@@ -1,10 +1,5 @@
-#version 330 core
-
 layout ( points ) in;
 layout ( triangle_strip, max_vertices = 14 ) out;
-
-uniform mat4 modelview;
-uniform mat4 projection;
 
 flat in vec3 vdx[];
 flat in vec3 vleft_edge[];

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -1,4 +1,3 @@
-#version 330
 in vec4 model_vertex; // The location of the vertex in model space
 in vec3 in_dx;
 in vec3 in_left_edge;
@@ -11,14 +10,6 @@ flat out mat4 vinverse_pmvm;
 flat out vec3 vdx;
 flat out vec3 vleft_edge;
 flat out vec3 vright_edge;
-
-//// Uniforms
-uniform vec3 camera_pos;
-uniform mat4 modelview;
-uniform mat4 projection;
-
-uniform float near_plane;
-uniform float far_plane;
 
 void main()
 {

--- a/yt_idv/shaders/header.inc.glsl
+++ b/yt_idv/shaders/header.inc.glsl
@@ -1,0 +1,1 @@
+#version 330 core

--- a/yt_idv/shaders/known_uniforms.inc.glsl
+++ b/yt_idv/shaders/known_uniforms.inc.glsl
@@ -1,0 +1,41 @@
+// Box annotation control
+uniform float box_alpha;
+uniform float box_width;
+uniform vec3 box_color;
+
+// Colormap control
+uniform float cmap_log;
+uniform float cmap_max;
+uniform float cmap_min;
+
+// Text control
+uniform float scale;
+uniform float x_offset;
+uniform float x_origin;
+uniform float y_offset;
+uniform float y_origin;
+
+// Transfer function control
+uniform float tf_log;
+uniform float tf_max;
+uniform float tf_min;
+
+// Control of RGB channel information
+uniform int channel;
+
+// Mesh rendering
+uniform mat4 model_to_clip;
+
+// Matrices for projection and positions
+uniform mat4 modelview;
+uniform mat4 projection;
+uniform vec3 camera_pos;
+uniform vec4 viewport; // (offset_x, offset_y, 1 / screen_x, 1 / screen_y)
+
+// textures we tend to use
+uniform sampler1D cm_tex;
+uniform sampler2D db_tex;
+uniform sampler2D fb_tex;
+uniform sampler2D tf_tex;
+uniform sampler3D bitmap_tex;
+uniform sampler3D ds_tex;

--- a/yt_idv/shaders/mesh.frag.glsl
+++ b/yt_idv/shaders/mesh.frag.glsl
@@ -1,10 +1,10 @@
 #version 330 core
 
-in float fragmentData;
-out vec4 color;
+in float fragment_data;
+out vec4 output_color;
 
 void main()
 {
-    color = vec4(fragmentData);
-    color.a = 1.0;
+    output_color = vec4(fragment_data);
+    output_color.a = 1.0;
 }

--- a/yt_idv/shaders/mesh.frag.glsl
+++ b/yt_idv/shaders/mesh.frag.glsl
@@ -1,5 +1,3 @@
-#version 330 core
-
 in float fragment_data;
 out vec4 output_color;
 

--- a/yt_idv/shaders/mesh.vert.glsl
+++ b/yt_idv/shaders/mesh.vert.glsl
@@ -3,9 +3,10 @@
 in vec4 model_vertex;
 in float vertex_data;
 out float fragment_data;
-uniform mat4 model
+uniform mat4 modelview;
+uniform mat4 projection;
 void main()
 {
-    gl_Position = modelview * projection * model_vertex;
-    fragmentData = vertexData;
+    gl_Position = projection * modelview * model_vertex;
+    fragment_data = vertex_data;
 }

--- a/yt_idv/shaders/mesh.vert.glsl
+++ b/yt_idv/shaders/mesh.vert.glsl
@@ -1,11 +1,11 @@
 #version 330 core
 
-in vec3 vertexPosition_modelspace;
-in float vertexData;
-out float fragmentData;
-uniform mat4 model_to_clip;
+in vec4 model_vertex;
+in float vertex_data;
+out float fragment_data;
+uniform mat4 model
 void main()
 {
-    gl_Position = model_to_clip * vec4(vertexPosition_modelspace, 1);
+    gl_Position = modelview * projection * model_vertex;
     fragmentData = vertexData;
 }

--- a/yt_idv/shaders/mesh.vert.glsl
+++ b/yt_idv/shaders/mesh.vert.glsl
@@ -1,10 +1,6 @@
-#version 330 core
-
 in vec4 model_vertex;
 in float vertex_data;
 out float fragment_data;
-uniform mat4 modelview;
-uniform mat4 projection;
 void main()
 {
     gl_Position = projection * modelview * model_vertex;

--- a/yt_idv/shaders/noop.frag.glsl
+++ b/yt_idv/shaders/noop.frag.glsl
@@ -1,16 +1,6 @@
-#version 330 core
-
 in vec2 UV;
 
 out vec4 color;
-
-uniform sampler2D fb_tex;
-uniform sampler1D cm_tex;
-uniform float min_val;
-uniform float scale;
-uniform float cmap_min;
-uniform float cmap_max;
-uniform float cmap_log;
 
 void main(){
    color = texture(fb_tex, UV);

--- a/yt_idv/shaders/noop.frag.glsl
+++ b/yt_idv/shaders/noop.frag.glsl
@@ -4,8 +4,8 @@ in vec2 UV;
 
 out vec4 color;
 
-uniform sampler2D fb_texture;
-uniform sampler1D cmap;
+uniform sampler2D fb_tex;
+uniform sampler1D cm_tex;
 uniform float min_val;
 uniform float scale;
 uniform float cmap_min;
@@ -13,5 +13,5 @@ uniform float cmap_max;
 uniform float cmap_log;
 
 void main(){
-   color = texture(fb_texture, UV);
+   color = texture(fb_tex, UV);
 }

--- a/yt_idv/shaders/passthrough.frag.glsl
+++ b/yt_idv/shaders/passthrough.frag.glsl
@@ -3,11 +3,11 @@
 in vec2 UV;
 
 out vec4 color;
-uniform sampler2D fb_texture;
-uniform sampler2D db_texture;
+uniform sampler2D fb_tex;
+uniform sampler2D db_tex;
 
 void main(){
-   color = texture(fb_texture, UV);
+   color = texture(fb_tex, UV);
    color.a = 1.0;
-   gl_FragDepth = texture(db_texture, UV).r;
+   gl_FragDepth = texture(db_tex, UV).r;
 }

--- a/yt_idv/shaders/passthrough.frag.glsl
+++ b/yt_idv/shaders/passthrough.frag.glsl
@@ -1,10 +1,6 @@
-#version 330 core
-
 in vec2 UV;
 
 out vec4 color;
-uniform sampler2D fb_tex;
-uniform sampler2D db_tex;
 
 void main(){
    color = texture(fb_tex, UV);

--- a/yt_idv/shaders/passthrough.vert.glsl
+++ b/yt_idv/shaders/passthrough.vert.glsl
@@ -1,5 +1,3 @@
-#version 330 core
-
 // Input vertex data, different for all executions of this shader.
 in vec3 vertexPosition_modelspace;
 

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -1,4 +1,3 @@
-#version 330
 flat in vec4 v_model;
 flat in vec3 v_camera_pos;
 flat in vec3 dx;
@@ -8,15 +7,6 @@ flat in mat4 inverse_proj;
 flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
 out vec4 output_color;
-
-uniform vec3 camera_pos;
-uniform mat4 modelview;
-uniform mat4 projection;
-
-uniform sampler3D ds_tex;
-uniform sampler3D bitmap_tex;
-//layout (binding = 1) uniform sampler2D depth_tex;
-uniform vec4 viewport; // (offset_x, offset_y, 1 / screen_x, 1 / screen_y)
 
 bool within_bb(vec3 pos)
 {

--- a/yt_idv/shaders/textoverlay.frag.glsl
+++ b/yt_idv/shaders/textoverlay.frag.glsl
@@ -1,10 +1,6 @@
-#version 330 core
-
 in vec2 UV;
 
 out vec4 color;
-uniform sampler2D fb_tex;
-uniform sampler2D db_tex;
 
 void main(){
    float val = texture(fb_tex, UV).r;

--- a/yt_idv/shaders/textoverlay.frag.glsl
+++ b/yt_idv/shaders/textoverlay.frag.glsl
@@ -3,11 +3,11 @@
 in vec2 UV;
 
 out vec4 color;
-uniform sampler2D fb_texture;
-uniform sampler2D db_texture;
+uniform sampler2D fb_tex;
+uniform sampler2D db_tex;
 
 void main(){
-   float val = texture(fb_texture, UV).r;
+   float val = texture(fb_tex, UV).r;
    gl_FragDepth = 0.0;
    if(val == 0) discard;
    color = vec4(val);

--- a/yt_idv/shaders/textoverlay.vert.glsl
+++ b/yt_idv/shaders/textoverlay.vert.glsl
@@ -1,18 +1,11 @@
-#version 330
 in vec4 quad_vertex; // The location of the vertex in model space
-uniform float x_offset;
-uniform float y_offset;
-uniform vec4 viewport;
-uniform float scale;
-uniform float y_origin;
-uniform float x_origin;
 
 out vec2 UV;
 
 void main()
 {
-    // What we're passed in is all in 64/th of pixels.  Our quad_vertex 
-    // runs from 0 .. width, 0 .. height.  Our x_offset is also in 64/th 
+    // What we're passed in is all in 64/th of pixels.  Our quad_vertex
+    // runs from 0 .. width, 0 .. height.  Our x_offset is also in 64/th
     // of pixels, and same for y_offset.
     // Note also that our offset is from the top.  So what we need to compute
     // is the dx and dy, for coordinates per pixel.
@@ -25,7 +18,7 @@ void main()
     // then set the origin to be 0.0 (clip) and offset by - y_offset * dy.
     gl_Position = vec4( dx * (quad_vertex.x + x_offset) + x_origin,
                         dy * (quad_vertex.y + y_offset) + y_origin,
-                        0.0, 1.0); 
+                        0.0, 1.0);
     UV = vec2(quad_vertex.wz);
-    
+
 }

--- a/yt_idv/shaders/transfer_function.frag.glsl
+++ b/yt_idv/shaders/transfer_function.frag.glsl
@@ -1,8 +1,3 @@
-uniform float tf_min;
-uniform float tf_max;
-uniform float tf_log;
-uniform sampler2D tf_tex;
-
 bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
                     float t, vec3 dir)
 {
@@ -12,9 +7,9 @@ bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
 
     float map_sample = texture(bitmap_tex, tex_curr_pos).r;
     if (!(map_sample > 0.0)) return false;
- 
+
     float tex_sample = texture(ds_tex, tex_curr_pos).r;
- 
+
     if (tf_log > 0.5) {
        if(tex_sample <= 0.0) return false;
        tex_sample = log(tex_sample);
@@ -33,7 +28,7 @@ bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
     return true;
 }
 
-vec4 cleanup_phase(in vec4 curr_color, in vec3 dir, in float t0, in float t1) 
+vec4 cleanup_phase(in vec4 curr_color, in vec3 dir, in float t0, in float t1)
 {
   // It's possible we need to scale, in which case this may be useful:
   // vec3 p0 = v_camera_pos.xyz + dir * t0;


### PR DESCRIPTION
I kind of did two things in this, and it's not totally done.

First -- it makes the mesh rendering work, and adds an example for that.

Second -- it starts to make the shader variables more uniform in naming scheme.  I'm going to see if I can write this up, or put them into a definitions file or something, and then see what can be yanked out and in a base class.  This part isn't done, although I've started with the `.inc` file.
